### PR TITLE
Update snapshots to reflect change in default time ranges

### DIFF
--- a/src/components/ConfirmCard/__snapshots__/index.test.js.snap
+++ b/src/components/ConfirmCard/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`ConfirmCard should match the snapshot 1`] = `
   <p>
     Fri Apr 07 2019
      at 
-    12:00 - 12:50 p.m.
+    12:00 - 12:30 p.m.
   </p>
   <label
     htmlFor="notes"
@@ -57,7 +57,7 @@ exports[`ConfirmCard should match the snapshot if the user has an opening alread
   <p>
     Fri Apr 07 2019
      at 
-    12:00 - 12:50 p.m.
+    12:00 - 12:30 p.m.
   </p>
   <label
     htmlFor="notes"

--- a/src/components/ConflictCard/__snapshots__/index.test.js.snap
+++ b/src/components/ConflictCard/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`ConflictCard should match the snapshot 1`] = `
     Wed Apr 17 2019
      from
      
-    8:00 - 8:50 a.m.
+    8:00 - 8:30 a.m.
   </p>
   <p>
     Please go back and choose a different date/time or adjust your schedule

--- a/src/components/ScheduleCard/__snapshots__/index.test.js.snap
+++ b/src/components/ScheduleCard/__snapshots__/index.test.js.snap
@@ -12,7 +12,7 @@ exports[`ScheduleCard should match the snapshot when there are no notes 1`] = `
   <p
     className="ScheduleCard--time"
   >
-    8:00 - 8:50 a.m.
+    8:00 - 8:30 a.m.
   </p>
   <h3
     className="ScheduleCard--name"
@@ -58,7 +58,7 @@ exports[`ScheduleCard should match the snapshot when there are notes 1`] = `
   <p
     className="ScheduleCard--time"
   >
-    8:00 - 8:50 a.m.
+    8:00 - 8:30 a.m.
   </p>
   <h3
     className="ScheduleCard--name"

--- a/src/containers/Availability/__snapshots__/index.test.js.snap
+++ b/src/containers/Availability/__snapshots__/index.test.js.snap
@@ -16,13 +16,13 @@ exports[`Availability Availability component should match the snapshot when the 
       <tr>
         <th />
         <th>
-          8:00 - 8:50 a.m.
+          8:00 - 8:30 a.m.
         </th>
         <th>
-          12:00 - 12:50 p.m.
+          12:00 - 12:30 p.m.
         </th>
         <th>
-          4:10 - 5:00 p.m.
+          4:10 - 4:40 p.m.
         </th>
       </tr>
     </thead>
@@ -204,13 +204,13 @@ exports[`Availability Availability component should match the snapshot when the 
       <tr>
         <th />
         <th>
-          8:00 - 8:50 a.m.
+          8:00 - 8:30 a.m.
         </th>
         <th>
-          12:00 - 12:50 p.m.
+          12:00 - 12:30 p.m.
         </th>
         <th>
-          4:10 - 5:00 p.m.
+          4:10 - 4:40 p.m.
         </th>
       </tr>
     </thead>

--- a/src/containers/StudentCard/__snapshots__/index.test.js.snap
+++ b/src/containers/StudentCard/__snapshots__/index.test.js.snap
@@ -53,7 +53,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        8:00 - 8:50 a.m.
+        8:00 - 8:30 a.m.
       </p>
       <button
         className="StudentCard--btn"
@@ -68,7 +68,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        12:00 - 12:50 p.m.
+        12:00 - 12:30 p.m.
       </p>
       <button
         className="StudentCard--btn"
@@ -83,7 +83,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        4:10 - 5:00 p.m.
+        4:10 - 4:40 p.m.
       </p>
       <button
         className="StudentCard--btn"
@@ -151,7 +151,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        8:00 - 8:50 a.m.
+        8:00 - 8:30 a.m.
       </p>
       <p>
         Not Available
@@ -161,7 +161,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        12:00 - 12:50 p.m.
+        12:00 - 12:30 p.m.
       </p>
       <p>
         Not Available
@@ -171,7 +171,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        4:10 - 5:00 p.m.
+        4:10 - 4:40 p.m.
       </p>
       <p>
         Not Available
@@ -234,7 +234,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        8:00 - 8:50 a.m.
+        8:00 - 8:30 a.m.
       </p>
       <p>
         Not Available
@@ -244,7 +244,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        12:00 - 12:50 p.m.
+        12:00 - 12:30 p.m.
       </p>
       <button
         className="StudentCard--btn"
@@ -259,7 +259,7 @@ exports[`StudentCard StudentCard component should match the snapshot when the st
       <p
         className="StudentCard-time-text"
       >
-        4:10 - 5:00 p.m.
+        4:10 - 4:40 p.m.
       </p>
       <p>
         Not Available


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed:
Updates Jest snapshots to reflect a change made sometime since the test suite was last run to the default time ranges displayed for "morning," "lunch," and "afternoon."
I did this by running `npm run test:dev`, running the test suite, then pressing `u` when prompted to update the snapshots, as described in our local deployment setup gist.

List any dependencies that are required for this change:
N/A

Fixes or Closes # (issue)
N/A

## Where should the reviewer start?:
This is more of a routine fix but the file differences should make it apparent what took place.

## image or gif (optional):

## Additional information for the reviewer:
