### PR TITLE
Fixing FE queries

### DIFF
--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -62,7 +62,8 @@ export const getUserPairings = userId => ({
 
 export const updatePairing = (pairingId, paireeId, notes) => ({
   query: `mutation {
-    updatePairing(pairing: {
+    updatePairing(
+      input: {
         id: "${pairingId}"
         pairee: "${paireeId}"
         notes: "${notes}"
@@ -117,7 +118,7 @@ export const createUser = ({
 }) => ({
   query: `mutation {
     user: createUser(
-      user: {
+      input: {
         name: "${name}"
         email: "${email}"
         phoneNumber: "${phoneNumber}"
@@ -219,7 +220,7 @@ export const updateUser = ({
 }) => ({
   query: `mutation {
     user: updateUser(
-      user: {
+      input: {
         id: "${id}"
         name: "${name}"
         email: "${email}"
@@ -251,7 +252,7 @@ export const updateUserImage = ({
 }) => ({
   query: `mutation {
     user: updateUser(
-      user: {
+      input: {
         id: "${id}"
         image: "${image}"
       }

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -154,6 +154,7 @@ export const getUserByFirebaseID = id => ({
     image
     pronouns
     email
+    phoneNumber
     slack
     skills
   }


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- ~~[ ] Link to project~~ [paired-be](https://github.com/DanielEFrampton/paired-be/projects/1)

### Issues Resolved
Resolves [Issue 55](https://github.com/DanielEFrampton/paired-be/issues/55) in `paired-be`

### Problem Addressed
The GraphQL syntax used by the `graphql-ruby` gem was either different from the previous Apollo server's syntax or we have implemented our types, etc., differently, and mutations which introduced their arguments with `user:` were not working unless replaced manually with `input:` per docs.

### Solution Implemented
Modified the FE queries accordingly. 

### Other Notes
Also added phone number to getUserByFirebaseID query. Notified @Capleugh so we can update spec file on BE.