### PR TITLE
Change GraphQL endpoint URL to deployed BE

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: node_js
 node_js:
-  - "10"
+- '10'
 warnings_are_errors: false
 install:
-  - npm install
+- npm install
 script:
-  - npm run build
-# deploy:
-#   provider: firebase
-#   skip_cleanup: true
-#   token:
-#     secure: Ac9BTslv8zmRUI6LOyDmfEnJ/eRZ+EPxKKz4Q5NUUohXADpE3B3jC7CMdyTm7qDD633gev4Nx1CsLZ3yYatVQGIpq24UufZ8Qp86Ifg+i2/Ii6/mSuROfhzGfljZfeGNWIQJZXjgPRtdepA2O3XalTBVFUeJoQZt9o5lVwDgmAdS1R+P1vM3dJ1towuZXUH+EJc2lpPmKtTYL0wo/XMRFaBUOmfSHQN8gvjVoMyPzrW3S4Sigwg8YVG5tjdr5EFWX8Mn0x10NfBIxczYGMFtMXCdoVYR+Q7Uq85gSbBtBk1FQ9W4A0bhbUvKiM012+snKWzKG3FwTR1FrhuRLeGsUz3GG+ZnlTL0iDxbrmgenib2aw2he/rR0i52kNhsjCFT/SwVL/eMZhuJTLsU719r7ykvPTdx+4vp89fZccgCMA/lydH8BOiGjfT3xL1A/jsvEtF6MfskrwzYg/S0xoyRqyjZGOCq27IxPaYxS6MGCOhOlSnCfdYZ776VECrYSJ/a4V/nwMg5GMeDaTYKcw8eMwWrDiVo1ALCxksYfSdnBxxjthloUKnE71jEKRfbVsLv7Y5qqUjyKeASROlcohMbH7FVmQIm/16yXs2w7a5yjeYp3UpFz7yFtfcJH1LBfTmANM+1lfbqBRpXAxmljkanc+ADKxE8OOgmIgiVrlIsFsM=
+- npm run build
+stages:
+  - test
+  - name: deploy
+    if: type = push AND branch = master
+jobs:
+  include:
+    - stage: test
+    - stage: deploy
+      deploy:
+        provider: heroku
+        api_key:
+          secure: QjKlucOm6/kCXlH3oCNeiSKC9NywHF5Mu5JxQ1gtJSbUHwsnH4D25rrNFaJG+MpC2GFlUlxHowdrLPlj2A+kgx8/MCsN3evIggF5zwwPxaZr7jgp6Po7LzUoTfaFWO18ulHvFehYW8147kJDmRMRrPly+++eVGDTlqu2IFnQh2v+kt6hGDPtQqfCfG9gbaN+RX4sBUnt/XfAEfiTygcSEQKPDZDE1h9TclxQfsgPCnGa068MBzyz1Mg+0YkwDOhLRuezb6Urar26+fvy/vgHMPRXWfldaWNMD3YnU5AHOLZ5aJVS3oqiUd0xfQV28/C/gmqaN23JtF4fl9Jr7KEIbBaRyqSjoQ/g/aFUxejGDgGyZTqdaGJ6/MFdninpSbUEkeh3mAQvDaqMphLLNgCkYHwP3EcXqapYWn3yslXKHTDQVxx9MQAh+9lPKY8B3kWRsbEqM7SDw6SpMVYalLbWSsXimBamOzGxyZTjjse+X70j1HChAcSBDGNCs1OXkpJWnKfHiRMEfo8LB5iMv/aZFj1by9ZR6oZ2w18mY7ySatcdk6M+VA94bvpFU6Q6cGIi/Gt5BJ+R8fvzVSFmAYvibbm4rssDOztRY/roA+fEtWWl6fjzI2kN1xvNyXTe7bkjiOzijw7jmm/wwBOlgVcrohVe2AXxAesdiLvgoAyeRlM=

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,5 @@
 export const fetchData = async body => {
-  const url = 'http://localhost:3001/graphql';
+  const url = 'https://paired-be.herokuapp.com/graphql';
   const response = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project board ([paired-be](https://github.com/DanielEFrampton/paired-be/projects/1))

### Issues Resolved
Resolves one half of [Issue 58](https://github.com/DanielEFrampton/paired-be/issues/58), splitting off unresolved portion as new issue.

### Problem Addressed
We modified the URL for the GraphQL endpoint to look for localhost:3000, so the deployed FE would not get past logging in (fails at getUser).

### Solution Implemented
Modified the URL again to point to the deployed Rails BE.

### Other Notes
Also set up Travis config file to auto-deploy like the BE repo.