### PR TITLE
Modify handleChange helper method to not lowercase phoneNumber variable

### DIFF
--- a/src/containers/Profile/__snapshots__/index.test.js.snap
+++ b/src/containers/Profile/__snapshots__/index.test.js.snap
@@ -76,7 +76,7 @@ exports[`Profile Profile component should match the snapshot 1`] = `
         className="Profile--input"
         name="phoneNumber"
         onChange={[Function]}
-        value="1234567890"
+        value=""
       />
       <label
         htmlFor="slack"

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -12,7 +12,7 @@ export class Profile extends Component {
     this.state = {
       name: this.props.name || '',
       email: this.props.email || '',
-      phoneNumber: this.props.phoneNumber || '',
+      phoneNumber: '',
       program: '',
       module: '',
       pronouns: '',
@@ -75,7 +75,9 @@ export class Profile extends Component {
 
   handleChange = event => {
     let { value, name } = event.target;
-    name = name.toLowerCase();
+    if (name != 'phoneNumber') {
+      name = name.toLowerCase();
+    }
     this.setState({ [name]: value });
   };
 

--- a/src/containers/Profile/index.js
+++ b/src/containers/Profile/index.js
@@ -75,7 +75,7 @@ export class Profile extends Component {
 
   handleChange = event => {
     let { value, name } = event.target;
-    if (name != 'phoneNumber') {
+    if (name !== 'phoneNumber') {
       name = name.toLowerCase();
     }
     this.setState({ [name]: value });

--- a/src/containers/Profile/index.test.js
+++ b/src/containers/Profile/index.test.js
@@ -30,7 +30,7 @@ describe('Profile', () => {
       const expected = {
         name: mockProps.name,
         email: mockProps.email,
-        phoneNumber: mockProps.phoneNumber,
+        phoneNumber: '',
         program: '',
         module: '',
         pronouns: '',

--- a/src/mockData/index.js
+++ b/src/mockData/index.js
@@ -311,9 +311,10 @@ export const mockQueryFromupdatePairing = {
 
 export const mockQueryFromdeletePairing = {
          query: `mutation {
-    deletePairing(id: "45dtl") {
-      date
-    }
+    deletePairing( input: { id: "45dtl" })
+      {
+        date
+      }
   }`
        };
 


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project board ([paired-be](https://github.com/DanielEFrampton/paired-be/projects/1))

### Issues Resolved
Resolves [Issue 85](https://github.com/DanielEFrampton/paired-be/issues/85)

### Problem Addressed
When creating or editing a user, the phone number field was not changeable; and because it was required, new users could not be created.

### Solution Implemented
Used conditional statement to not run a helper method which was being used to down-case the label names of the dropdown skill menus.

### Other Notes
It would be good to come back and refactor this later so that down-casing the input element names is not necessary.