### PR TITLE
Add cancel button to pairings card

### DIFF
--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -8,6 +8,11 @@ export const setError = error => ({
   error
 });
 
+export const cancelPairing = id => ({
+  type: 'CANCEL_PAIRING'
+  id
+});
+
 export const setUser = user => ({
   type: 'SET_USER',
   user

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -9,7 +9,7 @@ export const setError = error => ({
 });
 
 export const cancelPairing = id => ({
-  type: 'CANCEL_PAIRING'
+  type: 'CANCEL_PAIRING',
   id
 });
 

--- a/src/components/ScheduleCard/index.js
+++ b/src/components/ScheduleCard/index.js
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react';
 import { determineDisplayTime, determineProgram } from '../../helpers';
 import PropTypes from 'prop-types';
 
-export const ScheduleCard = ({ booking, person, deletePairing }) => {
+export const ScheduleCard = ({ booking, person, deletePairing, cancelPairing }) => {
   const { notes, time, date, id } = booking;
   return (
     <div className='ScheduleCard'>
@@ -17,6 +17,11 @@ export const ScheduleCard = ({ booking, person, deletePairing }) => {
             Program: {determineProgram(person.program, person.module)}
           </p>
           <p className='ScheduleCard--p'>Notes: {notes ? notes : 'no notes'}</p>
+          <button
+            onClick={() => cancelPairing(id)}
+            className='ScheduleCard--button'>
+            Cancel
+          </button>
         </Fragment>
       )}
       {!person && (
@@ -33,5 +38,6 @@ export const ScheduleCard = ({ booking, person, deletePairing }) => {
 ScheduleCard.propTypes = {
   booking: PropTypes.object,
   deletePairing: PropTypes.func,
+  cancelPairing: PropTypes.func,
   person: PropTypes.object
 };

--- a/src/components/ScheduleCard/index.js
+++ b/src/components/ScheduleCard/index.js
@@ -18,7 +18,7 @@ export const ScheduleCard = ({ booking, person, deletePairing, cancelPairing }) 
           </p>
           <p className='ScheduleCard--p'>Notes: {notes ? notes : 'no notes'}</p>
           <button
-            onClick={() => cancelPairing(id)}
+            onClick={() => cancelPairing(id) }
             className='ScheduleCard--button'>
             Cancel
           </button>
@@ -26,7 +26,7 @@ export const ScheduleCard = ({ booking, person, deletePairing, cancelPairing }) 
       )}
       {!person && (
         <button
-          onClick={() => deletePairing(id)}
+          onClick={() => deletePairing(id) }
           className='ScheduleCard--button'>
           Cancel
         </button>

--- a/src/containers/Confirmation/index.js
+++ b/src/containers/Confirmation/index.js
@@ -4,6 +4,8 @@ import ConfirmCard from '../../components/ConfirmCard';
 import { ConflictCard } from '../../components/ConflictCard';
 import { confirmPairing } from '../../thunks/confirmPairing';
 import { deletePairingThunk } from '../../thunks/deletePairingThunk';
+import { cancelMentorPairing } from '../../thunks/cancelMentorPairing';
+import { cancelMenteePairing } from '../../thunks/cancelMenteePairing';
 import PropTypes from 'prop-types';
 import * as gql from '../../queries';
 import { fetchData } from '../../utils';
@@ -53,6 +55,8 @@ export class Confirmation extends Component {
       user,
       confirmPairing,
       deletePairingThunk,
+      cancelMenteePairing,
+      cancelMentorPairing,
       match
     } = this.props;
     if (pairee === null) {
@@ -66,6 +70,8 @@ export class Confirmation extends Component {
           history={history}
           confirmPairing={confirmPairing}
           deletePairingThunk={deletePairingThunk}
+          cancelMenteePairing={cancelMenteePairing}
+          cancelMentorPairing={cancelMentorPairing}
           userId={user.id}
           pairingInConflictId={id}
         />
@@ -87,6 +93,8 @@ export class Confirmation extends Component {
       user,
       confirmPairing,
       deletePairingThunk,
+      cancelMenteePairing,
+      cancelMentorPairing,
       match
     } = this.props;
     return (
@@ -102,6 +110,8 @@ export class Confirmation extends Component {
             history={history}
             confirmPairing={confirmPairing}
             deletePairingThunk={deletePairingThunk}
+            cancelMenteePairing={cancelMenteePairing}
+            cancelMentorPairing={cancelMentorPairing}
             userId={user.id}
           />
         )}
@@ -124,6 +134,8 @@ export const mapDispatchToProps = dispatch => ({
   confirmPairing: (pairingId, paireeId, notes) =>
     dispatch(confirmPairing(pairingId, paireeId, notes)),
   deletePairingThunk: pairingId => dispatch(deletePairingThunk(pairingId)),
+  cancelMenteePairing: pairingId => dispatch(cancelMenteePairing(pairingId)),
+  cancelMentorPairing: pairingId => dispatch(cancelMentorPairing(pairingId)),
   setError: error => dispatch(setError(error))
 });
 
@@ -136,6 +148,8 @@ Confirmation.propTypes = {
   availPairings: PropTypes.array,
   confirmPairing: PropTypes.func,
   deletePairingThunk: PropTypes.func,
+  cancelMenteePairing: PropTypes.func,
+  cancelMentorPairing: PropTypes.func,
   history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,

--- a/src/containers/Schedule/index.js
+++ b/src/containers/Schedule/index.js
@@ -153,6 +153,8 @@ export default connect(
 
 Schedule.propTypes = {
   deletePairingThunk: PropTypes.func,
+  cancelMenteePairing: PropTypes.func,
+  cancelMentorPairing: PropTypes.func,
   history: PropTypes.object,
   location: PropTypes.object,
   match: PropTypes.object,

--- a/src/containers/Schedule/index.js
+++ b/src/containers/Schedule/index.js
@@ -2,6 +2,7 @@ import React, { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { ScheduleCard } from '../../components/ScheduleCard';
 import { deletePairingThunk } from '../../thunks/deletePairingThunk';
+import { cancelMentorPairing } from '../../thunks/cancelMentorPairing';
 import { TemplateCard } from '../../components/TemplateCard';
 import PropTypes from 'prop-types';
 import { filterPastPairings } from '../../helpers';
@@ -32,7 +33,7 @@ export class Schedule extends Component {
   };
 
   filterPaireeBookings = () => {
-    const { schedule, user } = this.props;
+    const { schedule, user, cancelMentorPairing  } = this.props;
     const bookings = schedule.filter(pairing => {
       return (
         pairing.pairee !== null &&
@@ -46,6 +47,7 @@ export class Schedule extends Component {
           booking={booking}
           person={booking.pairer}
           key={booking.id}
+          cancelPairing={cancelMentorPairing}
         />
       );
     });
@@ -71,6 +73,7 @@ export class Schedule extends Component {
           booking={booking}
           person={booking.pairee}
           key={booking.id}
+          cancelPairing={cancelMentorPairing}
         />
       );
     });
@@ -137,7 +140,8 @@ export const mapStateToProps = state => ({
 });
 
 export const mapDispatchToProps = dispatch => ({
-  deletePairingThunk: id => dispatch(deletePairingThunk(id))
+  deletePairingThunk: id => dispatch(deletePairingThunk(id)),
+  cancelMentorPairing: id => dispatch(cancelMentorPairing(id))
 });
 
 export default connect(

--- a/src/containers/Schedule/index.js
+++ b/src/containers/Schedule/index.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { ScheduleCard } from '../../components/ScheduleCard';
 import { deletePairingThunk } from '../../thunks/deletePairingThunk';
 import { cancelMentorPairing } from '../../thunks/cancelMentorPairing';
+import { cancelMenteePairing } from '../../thunks/cancelMenteePairing';
 import { TemplateCard } from '../../components/TemplateCard';
 import PropTypes from 'prop-types';
 import { filterPastPairings } from '../../helpers';
@@ -59,7 +60,7 @@ export class Schedule extends Component {
   };
 
   filterPairerBookings = () => {
-    const { schedule, user } = this.props;
+    const { schedule, user, cancelMenteePairing } = this.props;
     const bookings = schedule.filter(pairing => {
       return (
         pairing.pairee !== null &&
@@ -73,7 +74,7 @@ export class Schedule extends Component {
           booking={booking}
           person={booking.pairee}
           key={booking.id}
-          cancelPairing={cancelMentorPairing}
+          cancelPairing={cancelMenteePairing}
         />
       );
     });
@@ -141,7 +142,8 @@ export const mapStateToProps = state => ({
 
 export const mapDispatchToProps = dispatch => ({
   deletePairingThunk: id => dispatch(deletePairingThunk(id)),
-  cancelMentorPairing: id => dispatch(cancelMentorPairing(id))
+  cancelMentorPairing: id => dispatch(cancelMentorPairing(id)),
+  cancelMenteePairing: id => dispatch(cancelMenteePairing(id))
 });
 
 export default connect(

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -20,9 +20,8 @@ export const getAvailablePairings = (program, mod, date) => ({
 
 export const cancelMenteePairing = (id) => ({
   query:
-    `{
-      mutation {
-        cancelMenteePairing(input: {
+    `  mutation {
+         cancelMenteePairing(input: {
                 id: "${id}"
                 }) {
           pairer {
@@ -37,14 +36,12 @@ export const cancelMenteePairing = (id) => ({
             time
             id
           }
-        }
       }`
     });
 
     export const cancelMentorPairing = (id) => ({
       query:
-        `{
-          mutation {
+        ` mutation {
             cancelMentorPairing(input: {
               id: "${id}"
               }) {
@@ -60,7 +57,6 @@ export const cancelMenteePairing = (id) => ({
                   time
                   id
                 }
-              }
             }`
         });
 

--- a/src/queries/index.js
+++ b/src/queries/index.js
@@ -18,6 +18,52 @@ export const getAvailablePairings = (program, mod, date) => ({
   }`
 });
 
+export const cancelMenteePairing = (id) => ({
+  query:
+    `{
+      mutation {
+        cancelMenteePairing(input: {
+                id: "${id}"
+                }) {
+          pairer {
+            name
+            email
+            phoneNumber
+          }
+          pairee {
+            name
+          }
+            date
+            time
+            id
+          }
+        }
+      }`
+    });
+
+    export const cancelMentorPairing = (id) => ({
+      query:
+        `{
+          mutation {
+            cancelMentorPairing(input: {
+              id: "${id}"
+              }) {
+                pairer {
+                  name
+                }
+                pairee {
+                  name
+                  email
+                  phoneNumber
+                }
+                  date
+                  time
+                  id
+                }
+              }
+            }`
+        });
+
 export const getUserStats = id => ({
   query: `{
     getUserStats(id: ${id}) {

--- a/src/reducers/scheduleReducer.js
+++ b/src/reducers/scheduleReducer.js
@@ -8,6 +8,10 @@ export const scheduleReducer = (state = [], action) => {
       return state.filter(pairing => {
         return pairing.id !== action.id;
       });
+    case 'CANCEL_PAIRING':
+      return state.filter(pairing => {
+        return pairing.id !== action.id;
+      });
     case 'ADD_TO_SCHEDULE':
       return [...state, action.pairing].sort((a, b) => {
         return new Date(a.date).getTime() - new Date(b.date).getTime();

--- a/src/thunks/cancelMenteePairing.js
+++ b/src/thunks/cancelMenteePairing.js
@@ -1,0 +1,18 @@
+import { fetchData } from '../utils';
+import { setError, setLoading, cancelPairing } from '../actions';
+import * as gql from '../queries';
+
+export const cancelMenteePairing = (pairingId) => {
+  return async dispatch => {
+    try {
+      dispatch(setLoading(true));
+      const query = gql.cancelMenteePairing(pairingId);
+      await fetchData(query);
+      dispatch(setLoading(false));
+      dispatch(cancelPairing(pairingId));
+    } catch (error) {
+      dispatch(setLoading(false));
+      dispatch(setError(error.message));
+    }
+  };
+};

--- a/src/thunks/cancelMentorPairing.js
+++ b/src/thunks/cancelMentorPairing.js
@@ -1,0 +1,18 @@
+import { fetchData } from '../utils';
+import { setError, setLoading, cancelPairing } from '../actions';
+import * as gql from '../queries';
+
+export const cancelMentorPairing = (pairingId) => {
+  return async dispatch => {
+    try {
+      dispatch(setLoading(true));
+      const query = gql.cancelMentorPairing(pairingId);
+      await fetchData(query);
+      dispatch(setLoading(false));
+      dispatch(cancelPairing(pairingId));
+    } catch (error) {
+      dispatch(setLoading(false));
+      dispatch(setError(error.message));
+    }
+  };
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,6 @@
 export const fetchData = async body => {
-  const url = 'https://paired-be.herokuapp.com/graphql';
+  //const url = 'https://paired-be.herokuapp.com/graphql';
+  const url = 'http://localhost:3001/graphql';
   const response = await fetch(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #114 - creates feature for cancelling a mentor or mentee booking

### Problem Addressed
There was no way to cancel a pairing.
### Solution Implemented
Adds a cancel button for paired bookings. Once the pairing is cancelled it updates the mentor's availability to open for that time and day. It also sends a message to the other user that the pairing has been cancelled. 
### Other Notes
